### PR TITLE
Makefile: fix rule to build `audio.o`.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ all: run
 Pong.exe: main.c audio.o
 	$(CC) $(CFLAGS) -o Pong.exe main.c audio.o $(LDFLAGS)
 
-audio.o: audio.o
+audio.o: audio.c
 	$(CC) $(CFLAGS) -c audio.c $(LDFLAGS)
 
 .PHONY: Pong.exe


### PR DESCRIPTION
The Makefile rule `audio.o: audio.o` is a circular dependency. Now `audio.o: audio.c` states, that whenever `audio.o` is not existent is older than `audio.c`, it should be rebuilt.

Maybe this makes your hack obsolete? If you are interested, I propose a PR for a Makefile, that makes your project portable to Linux (got it already to work here on my system).

Anyways, thanks for your game!